### PR TITLE
Fix Slack channel URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a curated list of resources for the architecture framework created by Ub
 
 ## Slack channel
 
-* [RIBs Slack channel](uber-ribs.slack.com)
+* [RIBs Slack channel](https://uber-ribs.slack.com)
 
 ## Projects Using RIBs
 


### PR DESCRIPTION
Before link was:
https://github.com/jorgecoca/uber-ribs-awesome-resources/blob/master/uber-ribs.slack.com